### PR TITLE
Add CAGRA merge benchmark

### DIFF
--- a/cpp/bench/ann/CMakeLists.txt
+++ b/cpp/bench/ann/CMakeLists.txt
@@ -1,381 +1,540 @@
-# =============================================================================
-# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+#== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == \
+  == == == == == == =
+#Copyright(c) 2024 - 2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
+#Licensed under the Apache License, Version 2.0(the "License"); you may not use this file except
+#in compliance with the License.You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#http:  // www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
-# =============================================================================
+#Unless required by applicable law or agreed to in writing, software distributed under the License
+#is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.See the License for the specific language governing permissions and limitations under
+#the License.
+#== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == \
+  == == == == == == =
 
 list(APPEND CMAKE_MODULE_PATH "${CUVS_SOURCE_DIR}")
 
 # ##################################################################################################
-# * benchmark options ------------------------------------------------------------------------------
+#* \
+  benchmark options -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-option(CUVS_ANN_BENCH_USE_FAISS_GPU_FLAT "Include faiss' brute-force knn algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_FAISS_GPU_IVF_FLAT "Include faiss' ivf flat algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_FAISS_GPU_IVF_PQ "Include faiss' ivf pq algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_FAISS_GPU_CAGRA "Include faiss' cagra algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_FAISS_GPU_CAGRA_HNSW
-       "Include faiss' cagra algorithm for build and hnsw for search in benchmark" ON
-)
-option(CUVS_ANN_BENCH_USE_FAISS_CPU_FLAT "Include faiss' cpu brute-force algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_FAISS_CPU_IVF_FLAT "Include faiss' cpu ivf flat algorithm in benchmark"
-       ON
-)
-option(CUVS_ANN_BENCH_USE_FAISS_CPU_IVF_PQ "Include faiss' cpu ivf pq algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_FAISS_CPU_HNSW_FLAT "Include faiss' hnsw algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_CUVS_IVF_FLAT "Include cuVS ivf flat algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_CUVS_IVF_PQ "Include cuVS ivf pq algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_CUVS_CAGRA "Include cuVS CAGRA in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_CUVS_BRUTE_FORCE "Include cuVS brute force knn in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB "Include cuVS CAGRA with HNSW search in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_HNSWLIB "Include hnsw algorithm in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_GGNN "Include ggnn algorithm in benchmark" OFF)
-option(CUVS_ANN_BENCH_USE_DISKANN "Include DISKANN search in benchmark" ON)
-option(CUVS_ANN_BENCH_USE_CUVS_VAMANA "Include cuVS Vamana with DiskANN search in benchmark" ON)
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(ARM|arm|aarch64)")
-  set(CUVS_ANN_BENCH_USE_DISKANN OFF)
-  set(CUVS_ANN_BENCH_USE_CUVS_VAMANA OFF)
-endif()
-option(CUVS_ANN_BENCH_USE_CUVS_MG "Include cuVS ann mg algorithm in benchmark" ${BUILD_MG_ALGOS})
-option(CUVS_ANN_BENCH_SINGLE_EXE
-       "Make a single executable with benchmark as shared library modules" OFF
-)
-option(CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE "Include cuVS brute force knn in benchmark" ON)
-
-# ##################################################################################################
-# * Process options ----------------------------------------------------------
-
-find_package(Threads REQUIRED)
-
-set(CUVS_ANN_BENCH_USE_FAISS ON)
-set(CUVS_FAISS_ENABLE_GPU ON)
-set(CUVS_USE_FAISS_STATIC ON)
-
-if(BUILD_CPU_ONLY)
-  set(CUVS_FAISS_ENABLE_GPU OFF)
-  set(CUVS_ANN_BENCH_USE_CUVS_IVF_FLAT OFF)
-  set(CUVS_ANN_BENCH_USE_CUVS_IVF_PQ OFF)
-  set(CUVS_ANN_BENCH_USE_CUVS_CAGRA OFF)
-  set(CUVS_ANN_BENCH_USE_CUVS_BRUTE_FORCE OFF)
-  set(CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB OFF)
-  set(CUVS_ANN_BENCH_USE_GGNN OFF)
-  set(CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE OFF)
-  set(CUVS_ANN_BENCH_USE_CUVS_MG OFF)
-  set(CUVS_ANN_BENCH_USE_CUVS_VAMANA OFF)
-else()
-  set(CUVS_FAISS_ENABLE_GPU ON)
-endif()
-
-set(CUVS_ANN_BENCH_USE_CUVS OFF)
-if(CUVS_ANN_BENCH_USE_CUVS_IVF_PQ
-   OR CUVS_ANN_BENCH_USE_CUVS_BRUTE_FORCE
-   OR CUVS_ANN_BENCH_USE_CUVS_IVF_FLAT
-   OR CUVS_ANN_BENCH_USE_CUVS_CAGRA
-   OR CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB
-   OR CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE
-   OR CUVS_ANN_BENCH_USE_CUVS_MG
-   OR CUVS_ANN_BENCH_USE_CUVS_VAMANA
-)
-  set(CUVS_ANN_BENCH_USE_CUVS ON)
-endif()
+  option(CUVS_ANN_BENCH_USE_FAISS_GPU_FLAT
+         "Include faiss' brute-force knn algorithm in benchmark" ON)
+    option(CUVS_ANN_BENCH_USE_FAISS_GPU_IVF_FLAT
+           "Include faiss' ivf flat algorithm in benchmark" ON)
+      option(CUVS_ANN_BENCH_USE_FAISS_GPU_IVF_PQ "Include faiss' ivf pq algorithm in benchmark" ON)
+        option(CUVS_ANN_BENCH_USE_FAISS_GPU_CAGRA "Include faiss' cagra algorithm in benchmark" ON)
+          option(CUVS_ANN_BENCH_USE_FAISS_GPU_CAGRA_HNSW
+                 "Include faiss' cagra algorithm for build and hnsw for search in benchmark" ON)
+            option(CUVS_ANN_BENCH_USE_FAISS_CPU_FLAT
+                   "Include faiss' cpu brute-force algorithm in benchmark" ON)
+              option(CUVS_ANN_BENCH_USE_FAISS_CPU_IVF_FLAT
+                     "Include faiss' cpu ivf flat algorithm in benchmark" ON)
+                option(CUVS_ANN_BENCH_USE_FAISS_CPU_IVF_PQ
+                       "Include faiss' cpu ivf pq algorithm in benchmark" ON)
+                  option(CUVS_ANN_BENCH_USE_FAISS_CPU_HNSW_FLAT
+                         "Include faiss' hnsw algorithm in benchmark" ON)
+                    option(CUVS_ANN_BENCH_USE_CUVS_IVF_FLAT
+                           "Include cuVS ivf flat algorithm in benchmark" ON)
+                      option(CUVS_ANN_BENCH_USE_CUVS_IVF_PQ
+                             "Include cuVS ivf pq algorithm in benchmark" ON)
+                        option(CUVS_ANN_BENCH_USE_CUVS_CAGRA "Include cuVS CAGRA in benchmark" ON)
+                          option(CUVS_ANN_BENCH_USE_CUVS_BRUTE_FORCE
+                                 "Include cuVS brute force knn in benchmark" ON)
+                            option(CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB
+                                   "Include cuVS CAGRA with HNSW search in benchmark" ON)
+                              option(CUVS_ANN_BENCH_USE_HNSWLIB
+                                     "Include hnsw algorithm in benchmark" ON)
+                                option(CUVS_ANN_BENCH_USE_GGNN
+                                       "Include ggnn algorithm in benchmark" OFF)
+                                  option(CUVS_ANN_BENCH_USE_DISKANN
+                                         "Include DISKANN search in benchmark" ON)
+                                    option(CUVS_ANN_BENCH_USE_CUVS_VAMANA
+                                           "Include cuVS Vamana with DiskANN search in "
+                                           "benchmark" ON) if (CMAKE_SYSTEM_PROCESSOR MATCHES
+                                                               "(ARM|arm|aarch64)")
+                                      set(CUVS_ANN_BENCH_USE_DISKANN OFF)
+                                        set(CUVS_ANN_BENCH_USE_CUVS_VAMANA OFF) endif() option(
+                                          CUVS_ANN_BENCH_USE_CUVS_MG
+                                          "Include cuVS ann mg algorithm in benchmark" ${
+                                            BUILD_MG_ALGOS})
+                                          option(CUVS_ANN_BENCH_SINGLE_EXE
+                                                 "Make a single executable with benchmark as "
+                                                 "shared library modules" OFF)
+                                            option(CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE
+                                                   "Include cuVS brute force knn in benchmark" ON)
 
 # ##################################################################################################
-# * Fetch requirements -------------------------------------------------------------
+#* \
+  Process options -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-if(CUVS_ANN_BENCH_USE_HNSWLIB OR CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB)
-  include(cmake/thirdparty/get_hnswlib)
-endif()
+                                              find_package(Threads REQUIRED)
 
-include(cmake/thirdparty/get_nlohmann_json)
+                                                set(CUVS_ANN_BENCH_USE_FAISS ON) set(
+                                                  CUVS_FAISS_ENABLE_GPU
+                                                    ON) set(CUVS_USE_FAISS_STATIC ON)
 
-if(CUVS_ANN_BENCH_USE_GGNN)
-  include(cmake/thirdparty/get_ggnn)
-endif()
+                                                  if (BUILD_CPU_ONLY) set(
+                                                    CUVS_FAISS_ENABLE_GPU
+                                                      OFF) set(CUVS_ANN_BENCH_USE_CUVS_IVF_FLAT OFF)
+                                                    set(CUVS_ANN_BENCH_USE_CUVS_IVF_PQ OFF) set(
+                                                      CUVS_ANN_BENCH_USE_CUVS_CAGRA
+                                                        OFF) set(CUVS_ANN_BENCH_USE_CUVS_BRUTE_FORCE
+                                                                   OFF)
+                                                      set(CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB OFF)
+                                                        set(CUVS_ANN_BENCH_USE_GGNN OFF) set(
+                                                          CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE OFF)
+                                                          set(CUVS_ANN_BENCH_USE_CUVS_MG OFF) set(
+                                                            CUVS_ANN_BENCH_USE_CUVS_VAMANA
+                                                              OFF) else()
+                                                            set(CUVS_FAISS_ENABLE_GPU ON) endif()
 
-if(CUVS_ANN_BENCH_USE_DISKANN OR CUVS_ANN_BENCH_USE_CUVS_VAMANA)
-  include(cmake/thirdparty/get_diskann)
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS)
-  include(cmake/thirdparty/get_faiss)
-endif()
-
-# ##################################################################################################
-# * Target function -------------------------------------------------------------
-
-function(ConfigureAnnBench)
-
-  set(oneValueArgs NAME)
-  set(multiValueArgs PATH LINKS CXXFLAGS)
-
-  if(NOT BUILD_CPU_ONLY)
-    set(GPU_BUILD ON)
-  endif()
-
-  cmake_parse_arguments(
-    ConfigureAnnBench "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}
-  )
-
-  set(BENCH_NAME ${ConfigureAnnBench_NAME}_ANN_BENCH)
-
-  if(CUVS_ANN_BENCH_SINGLE_EXE)
-    add_library(${BENCH_NAME} SHARED ${ConfigureAnnBench_PATH})
-    string(TOLOWER ${BENCH_NAME} BENCH_LIB_NAME)
-    set_target_properties(${BENCH_NAME} PROPERTIES OUTPUT_NAME ${BENCH_LIB_NAME})
-    add_dependencies(${BENCH_NAME} ANN_BENCH)
-  else()
-    add_executable(${BENCH_NAME} ${ConfigureAnnBench_PATH})
-    target_compile_definitions(${BENCH_NAME} PRIVATE ANN_BENCH_BUILD_MAIN>)
-    target_link_libraries(
-      ${BENCH_NAME} PRIVATE benchmark::benchmark $<$<TARGET_EXISTS:CUDA::nvtx3>:CUDA::nvtx3>
-    )
-  endif()
-
-  target_link_libraries(
-    ${BENCH_NAME}
-    PRIVATE ${ConfigureAnnBench_LINKS}
-            nlohmann_json::nlohmann_json
-            Threads::Threads
-            $<$<BOOL:${GPU_BUILD}>:CUDA::cudart_static>
-            $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX>
-            $<TARGET_NAME_IF_EXISTS:conda_env>
-  )
-
-  set_target_properties(
-    ${BENCH_NAME}
-    PROPERTIES # set target compile options
-               CXX_STANDARD 17
-               CXX_STANDARD_REQUIRED ON
-               CUDA_STANDARD 17
-               CUDA_STANDARD_REQUIRED ON
-               POSITION_INDEPENDENT_CODE ON
-               INTERFACE_POSITION_INDEPENDENT_CODE ON
-               BUILD_RPATH "\$ORIGIN"
-               INSTALL_RPATH "\$ORIGIN"
-  )
-
-  set(${ConfigureAnnBench_CXXFLAGS} ${CUVS_CXX_FLAGS} ${ConfigureAnnBench_CXXFLAGS})
-
-  target_compile_options(
-    ${BENCH_NAME} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${ConfigureAnnBench_CXXFLAGS}>"
-                          "$<$<COMPILE_LANGUAGE:CUDA>:${CUVS_CUDA_FLAGS}>"
-  )
-
-  if(CUVS_ANN_BENCH_USE_${ConfigureAnnBench_NAME})
-    target_compile_definitions(
-      ${BENCH_NAME}
-      PUBLIC
-        CUVS_ANN_BENCH_USE_${ConfigureAnnBench_NAME}=CUVS_ANN_BENCH_USE_${ConfigureAnnBench_NAME}
-    )
-  endif()
-
-  target_include_directories(
-    ${BENCH_NAME}
-    PUBLIC "$<BUILD_INTERFACE:${CUVS_SOURCE_DIR}/include>"
-    PRIVATE ${ConfigureAnnBench_INCLUDES}
-  )
-
-  install(
-    TARGETS ${BENCH_NAME}
-    COMPONENT ann_bench
-    DESTINATION bin/ann
-  )
-
-  add_dependencies(CUVS_ANN_BENCH_ALL ${BENCH_NAME})
-endfunction()
+                                                              set(CUVS_ANN_BENCH_USE_CUVS OFF) if (
+                                                                CUVS_ANN_BENCH_USE_CUVS_IVF_PQ OR
+                                                                  CUVS_ANN_BENCH_USE_CUVS_BRUTE_FORCE
+                                                                    OR
+                                                                      CUVS_ANN_BENCH_USE_CUVS_IVF_FLAT
+                                                                        OR
+                                                                          CUVS_ANN_BENCH_USE_CUVS_CAGRA
+                                                                            OR
+                                                                              CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB
+                                                                                OR
+                                                                                  CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE
+                                                                                    OR CUVS_ANN_BENCH_USE_CUVS_MG OR CUVS_ANN_BENCH_USE_CUVS_VAMANA)
+                                                                set(CUVS_ANN_BENCH_USE_CUVS ON)
+                                                                  endif()
 
 # ##################################################################################################
-# * Configure benchmark targets -------------------------------------------------------------
+#* \
+  Fetch requirements -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
 
-if(NOT TARGET CUVS_ANN_BENCH_ALL)
-  add_custom_target(CUVS_ANN_BENCH_ALL)
-endif()
+                                                                    if (CUVS_ANN_BENCH_USE_HNSWLIB
+                                                                          OR CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB)
+                                                                      include(cmake / thirdparty /
+                                                                              get_hnswlib)
+                                                                        endif()
 
-if(CUVS_ANN_BENCH_USE_HNSWLIB)
-  ConfigureAnnBench(NAME HNSWLIB PATH src/hnswlib/hnswlib_benchmark.cpp LINKS hnswlib::hnswlib)
+                                                                          include(cmake / thirdparty /
+                                                                                  get_nlohmann_json)
 
-endif()
+                                                                            if (
+                                                                              CUVS_ANN_BENCH_USE_GGNN)
+                                                                              include(cmake / thirdparty /
+                                                                                      get_ggnn)
+                                                                                endif()
 
-if(CUVS_ANN_BENCH_USE_CUVS_IVF_PQ)
-  ConfigureAnnBench(
-    NAME CUVS_IVF_PQ PATH src/cuvs/cuvs_benchmark.cu src/cuvs/cuvs_ivf_pq.cu LINKS cuvs
-  )
-endif()
+                                                                                  if (CUVS_ANN_BENCH_USE_DISKANN
+                                                                                        OR CUVS_ANN_BENCH_USE_CUVS_VAMANA)
+                                                                                    include(cmake / thirdparty / get_diskann)
+                                                                                      endif()
 
-if(CUVS_ANN_BENCH_USE_CUVS_IVF_FLAT)
-  ConfigureAnnBench(
-    NAME CUVS_IVF_FLAT PATH src/cuvs/cuvs_benchmark.cu src/cuvs/cuvs_ivf_flat.cu LINKS cuvs
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_CUVS_BRUTE_FORCE)
-  ConfigureAnnBench(NAME CUVS_BRUTE_FORCE PATH src/cuvs/cuvs_benchmark.cu LINKS cuvs)
-endif()
-
-if(CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE)
-  ConfigureAnnBench(
-    NAME CUVS_KNN_BRUTE_FORCE PATH
-    $<$<BOOL:${CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE}>:src/cuvs/cuvs_brute_force_knn.cu> LINKS cuvs
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_CUVS_CAGRA)
-  ConfigureAnnBench(
-    NAME
-    CUVS_CAGRA
-    PATH
-    src/cuvs/cuvs_benchmark.cu
-    src/cuvs/cuvs_cagra_float.cu
-    src/cuvs/cuvs_cagra_half.cu
-    src/cuvs/cuvs_cagra_int8_t.cu
-    src/cuvs/cuvs_cagra_uint8_t.cu
-    LINKS
-    cuvs
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB)
-  ConfigureAnnBench(NAME CUVS_CAGRA_HNSWLIB PATH src/cuvs/cuvs_cagra_hnswlib.cu LINKS cuvs)
-endif()
-
-if(CUVS_ANN_BENCH_USE_CUVS_MG)
-  ConfigureAnnBench(
-    NAME
-    CUVS_MG
-    PATH
-    src/cuvs/cuvs_benchmark.cu
-    $<$<BOOL:${CUVS_ANN_BENCH_USE_CUVS_MG}>:src/cuvs/cuvs_mg_ivf_flat.cu>
-    $<$<BOOL:${CUVS_ANN_BENCH_USE_CUVS_MG}>:src/cuvs/cuvs_mg_ivf_pq.cu>
-    $<$<BOOL:${CUVS_ANN_BENCH_USE_CUVS_MG}>:src/cuvs/cuvs_mg_cagra.cu>
-    LINKS
-    cuvs
-    nccl
-  )
-endif()
-
-message("CUVS_FAISS_TARGETS: ${CUVS_FAISS_TARGETS}")
-message("CUDAToolkit_LIBRARY_DIR: ${CUDAToolkit_LIBRARY_DIR}")
-if(CUVS_ANN_BENCH_USE_FAISS_CPU_FLAT)
-  ConfigureAnnBench(
-    NAME FAISS_CPU_FLAT PATH src/faiss/faiss_cpu_benchmark.cpp LINKS ${CUVS_FAISS_TARGETS}
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS_CPU_IVF_FLAT)
-  ConfigureAnnBench(
-    NAME FAISS_CPU_IVF_FLAT PATH src/faiss/faiss_cpu_benchmark.cpp LINKS ${CUVS_FAISS_TARGETS}
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS_CPU_IVF_PQ)
-  ConfigureAnnBench(
-    NAME FAISS_CPU_IVF_PQ PATH src/faiss/faiss_cpu_benchmark.cpp LINKS ${CUVS_FAISS_TARGETS}
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS_CPU_HNSW_FLAT)
-  ConfigureAnnBench(
-    NAME FAISS_CPU_HNSW_FLAT PATH src/faiss/faiss_cpu_benchmark.cpp LINKS ${CUVS_FAISS_TARGETS}
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS_GPU_IVF_FLAT AND CUVS_FAISS_ENABLE_GPU)
-  ConfigureAnnBench(
-    NAME FAISS_GPU_IVF_FLAT PATH src/faiss/faiss_gpu_benchmark.cu LINKS ${CUVS_FAISS_TARGETS}
-    raft::raft
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS_GPU_IVF_PQ AND CUVS_FAISS_ENABLE_GPU)
-  ConfigureAnnBench(
-    NAME FAISS_GPU_IVF_PQ PATH src/faiss/faiss_gpu_benchmark.cu LINKS ${CUVS_FAISS_TARGETS}
-    raft::raft
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS_GPU_FLAT AND CUVS_FAISS_ENABLE_GPU)
-  ConfigureAnnBench(
-    NAME FAISS_GPU_FLAT PATH src/faiss/faiss_gpu_benchmark.cu LINKS ${CUVS_FAISS_TARGETS}
-    raft::raft
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS_GPU_CAGRA AND CUVS_FAISS_ENABLE_GPU)
-  ConfigureAnnBench(
-    NAME FAISS_GPU_CAGRA PATH src/faiss/faiss_gpu_benchmark.cu LINKS ${CUVS_FAISS_TARGETS}
-    raft::raft
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_FAISS_GPU_CAGRA_HNSW AND CUVS_FAISS_ENABLE_GPU)
-  ConfigureAnnBench(
-    NAME FAISS_GPU_CAGRA_HNSW PATH src/faiss/faiss_gpu_benchmark.cu LINKS ${CUVS_FAISS_TARGETS}
-    raft::raft
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_GGNN)
-  include(cmake/thirdparty/get_glog)
-  ConfigureAnnBench(
-    NAME GGNN PATH src/ggnn/ggnn_benchmark.cu LINKS glog::glog ggnn::ggnn CUDA::curand
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_DISKANN)
-  ConfigureAnnBench(
-    NAME DISKANN_MEMORY PATH src/diskann/diskann_benchmark.cpp LINKS diskann::diskann aio
-  )
-  ConfigureAnnBench(
-    NAME DISKANN_SSD PATH src/diskann/diskann_benchmark.cpp LINKS diskann::diskann aio
-  )
-endif()
-
-if(CUVS_ANN_BENCH_USE_CUVS_VAMANA)
-  ConfigureAnnBench(NAME CUVS_VAMANA PATH src/cuvs/cuvs_vamana.cu LINKS cuvs diskann::diskann aio)
-endif()
+                                                                                        if (CUVS_ANN_BENCH_USE_FAISS) include(cmake /
+                                                                                                                              thirdparty /
+                                                                                                                              get_faiss) endif()
 
 # ##################################################################################################
-# * Dynamically-loading ANN_BENCH executable -------------------------------------------------------
-if(CUVS_ANN_BENCH_SINGLE_EXE)
-  add_executable(ANN_BENCH src/common/benchmark.cpp)
+#* \
+  Target function -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
 
-  target_include_directories(ANN_BENCH PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+                                                                                          function(
+                                                                                            ConfigureAnnBench)
 
-  target_link_libraries(
-    ANN_BENCH PRIVATE raft::raft nlohmann_json::nlohmann_json benchmark::benchmark dl
-                      $<$<TARGET_EXISTS:CUDA::nvtx3>:CUDA::nvtx3>
-  )
-  set_target_properties(
-    ANN_BENCH
-    PROPERTIES # set target compile options
-               CXX_STANDARD 17
-               CXX_STANDARD_REQUIRED ON
-               CUDA_STANDARD 17
-               CUDA_STANDARD_REQUIRED ON
-               POSITION_INDEPENDENT_CODE ON
-               INTERFACE_POSITION_INDEPENDENT_CODE ON
-               BUILD_RPATH "\$ORIGIN"
-               INSTALL_RPATH "\$ORIGIN"
-  )
-  target_compile_definitions(
-    ANN_BENCH
-    PRIVATE
-      $<$<BOOL:${CUDAToolkit_FOUND}>:ANN_BENCH_LINK_CUDART="libcudart.so.${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}.${CUDAToolkit_VERSION_PATCH}">
-  )
+                                                                                            set(oneValueArgs
+                                                                                                  NAME)
+                                                                                              set(multiValueArgs PATH LINKS CXXFLAGS)
 
-  target_link_options(ANN_BENCH PRIVATE -export-dynamic)
+                                                                                                if (
+                                                                                                  NOT BUILD_CPU_ONLY) set(GPU_BUILD ON) endif()
 
-  install(
-    TARGETS ANN_BENCH
-    COMPONENT ann_bench
-    DESTINATION bin/ann
-    EXCLUDE_FROM_ALL
-  )
-endif()
+                                                                                                  cmake_parse_arguments(ConfigureAnnBench
+                                                                                                                        "${options}"
+                                                                                                                        "${oneValueArgs}"
+                                                                                                                        "${multiValueArgs}" ${
+                                                                                                                          ARGN})
+
+                                                                                                    set(BENCH_NAME
+                                                                                                          ${ConfigureAnnBench_NAME} _ANN_BENCH)
+
+                                                                                                      if (
+                                                                                                        CUVS_ANN_BENCH_SINGLE_EXE)
+                                                                                                        add_library(
+                                                                                                          ${
+                                                                                                            BENCH_NAME} SHARED ${ConfigureAnnBench_PATH})
+                                                                                                          string(TOLOWER ${BENCH_NAME} BENCH_LIB_NAME)
+                                                                                                            set_target_properties(
+                                                                                                              ${
+                                                                                                                BENCH_NAME} PROPERTIES OUTPUT_NAME ${
+                                                                                                                BENCH_LIB_NAME})
+                                                                                                              add_dependencies(${BENCH_NAME} ANN_BENCH) else()
+                                                                                                                add_executable(${BENCH_NAME} ${ConfigureAnnBench_PATH}) target_compile_definitions(${BENCH_NAME} PRIVATE ANN_BENCH_BUILD_MAIN >)
+                                                                                                                  target_link_libraries(${BENCH_NAME} PRIVATE benchmark::benchmark $<$<TARGET_EXISTS : CUDA::nvtx3> : CUDA::nvtx3>) endif()
+
+                                                                                                                    target_link_libraries(${BENCH_NAME} PRIVATE ${ConfigureAnnBench_LINKS} nlohmann_json::nlohmann_json Threads::Threads $<
+                                                                                                                                          $<
+                                                                                                                                            BOOL : ${GPU_BUILD}> : CUDA::cudart_static> $<TARGET_NAME_IF_EXISTS : OpenMP::OpenMP_CXX> $<TARGET_NAME_IF_EXISTS : conda_env>)
+
+                                                                                                                      set_target_properties(${
+                                                                                                                        BENCH_NAME} PROPERTIES #set target compile
+                                                                                                                                              options CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON POSITION_INDEPENDENT_CODE ON INTERFACE_POSITION_INDEPENDENT_CODE ON BUILD_RPATH
+                                                                                                                                            "\$ORIGIN" INSTALL_RPATH
+                                                                                                                                            "\$ORIGIN")
+
+                                                                                                                        set(${
+                                                                                                                          ConfigureAnnBench_CXXFLAGS} ${CUVS_CXX_FLAGS} ${
+                                                                                                                          ConfigureAnnBench_CXXFLAGS})
+
+                                                                                                                          target_compile_options(
+                                                                                                                            ${BENCH_NAME} PRIVATE
+                                                                                                                            "$<$<COMPILE_LANGUAGE:CXX>:${ConfigureAnnBench_CXXFLAGS}>"
+                                                                                                                            "$<$<COMPILE_LANGUAGE:CUDA>:${CUVS_CUDA_FLAGS}>")
+
+                                                                                                                            if (CUVS_ANN_BENCH_USE_${
+                                                                                                                                  ConfigureAnnBench_NAME}) target_compile_definitions(${BENCH_NAME} PUBLIC CUVS_ANN_BENCH_USE_${ConfigureAnnBench_NAME} = CUVS_ANN_BENCH_USE_${ConfigureAnnBench_NAME})
+                                                                                                                              endif()
+
+                                                                                                                                target_include_directories(
+                                                                                                                                  ${BENCH_NAME} PUBLIC
+                                                                                                                                  "$<BUILD_INTERFACE:${CUVS_SOURCE_DIR}/include>" PRIVATE
+                                                                                                                                    ${ConfigureAnnBench_INCLUDES})
+
+                                                                                                                                  install(
+                                                                                                                                    TARGETS ${
+                                                                                                                                      BENCH_NAME} COMPONENT ann_bench DESTINATION bin /
+                                                                                                                                    ann)
+
+                                                                                                                                    add_dependencies(
+                                                                                                                                      CUVS_ANN_BENCH_ALL
+                                                                                                                                        ${BENCH_NAME})
+                                                                                                                                      endfunction()
+
+# ##################################################################################################
+#* \
+  Configure benchmark targets -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+                                                                                                                                        if (
+                                                                                                                                          NOT TARGET
+                                                                                                                                            CUVS_ANN_BENCH_ALL)
+                                                                                                                                          add_custom_target(CUVS_ANN_BENCH_ALL) endif()
+
+                                                                                                                                            if (CUVS_ANN_BENCH_USE_HNSWLIB) ConfigureAnnBench(NAME
+                                                                                                                                                                                                HNSWLIB PATH
+                                                                                                                                                                                                  src /
+                                                                                                                                                                                              hnswlib /
+                                                                                                                                                                                              hnswlib_benchmark
+                                                                                                                                                                                                .cpp LINKS
+                                                                                                                                                                                                  hnswlib::
+                                                                                                                                                                                                    hnswlib)
+
+                                                                                                                                              endif()
+
+                                                                                                                                                if (
+                                                                                                                                                  CUVS_ANN_BENCH_USE_CUVS_IVF_PQ)
+                                                                                                                                                  ConfigureAnnBench(NAME
+                                                                                                                                                                      CUVS_IVF_PQ PATH
+                                                                                                                                                                        src /
+                                                                                                                                                                    cuvs /
+                                                                                                                                                                    cuvs_benchmark
+                                                                                                                                                                      .cu
+                                                                                                                                                                        src /
+                                                                                                                                                                    cuvs /
+                                                                                                                                                                    cuvs_ivf_pq
+                                                                                                                                                                      .cu
+                                                                                                                                                                        LINKS cuvs)
+                                                                                                                                                    endif()
+
+                                                                                                                                                      if (
+                                                                                                                                                        CUVS_ANN_BENCH_USE_CUVS_IVF_FLAT) ConfigureAnnBench(NAME CUVS_IVF_FLAT PATH src /
+                                                                                                                                                                                                            cuvs /
+                                                                                                                                                                                                            cuvs_benchmark
+                                                                                                                                                                                                              .cu
+                                                                                                                                                                                                                src /
+                                                                                                                                                                                                            cuvs /
+                                                                                                                                                                                                            cuvs_ivf_flat
+                                                                                                                                                                                                              .cu LINKS
+                                                                                                                                                                                                                cuvs)
+                                                                                                                                                        endif()
+
+                                                                                                                                                          if (
+                                                                                                                                                            CUVS_ANN_BENCH_USE_CUVS_BRUTE_FORCE) ConfigureAnnBench(NAME CUVS_BRUTE_FORCE
+                                                                                                                                                                                                                     PATH
+                                                                                                                                                                                                                       src /
+                                                                                                                                                                                                                   cuvs /
+                                                                                                                                                                                                                   cuvs_benchmark
+                                                                                                                                                                                                                     .cu LINKS
+                                                                                                                                                                                                                       cuvs) endif()
+
+                                                                                                                                                            if (
+                                                                                                                                                              CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE) ConfigureAnnBench(NAME
+                                                                                                                                                                                                                       CUVS_KNN_BRUTE_FORCE PATH $<$<BOOL : ${CUVS_KNN_BENCH_USE_CUVS_BRUTE_FORCE}> : src /
+                                                                                                                                                                                                                                                   cuvs /
+                                                                                                                                                                                                                                                   cuvs_brute_force_knn
+                                                                                                                                                                                                                                                     .cu>
+                                                                                                                                                                                                                         LINKS
+                                                                                                                                                                                                                           cuvs) endif()
+
+                                                                                                                                                              if (
+                                                                                                                                                                CUVS_ANN_BENCH_USE_CUVS_CAGRA) ConfigureAnnBench(NAME CUVS_CAGRA
+                                                                                                                                                                                                                   PATH
+                                                                                                                                                                                                                     src /
+                                                                                                                                                                                                                 cuvs /
+                                                                                                                                                                                                                 cuvs_benchmark
+                                                                                                                                                                                                                   .cu
+                                                                                                                                                                                                                     src /
+                                                                                                                                                                                                                 cuvs /
+                                                                                                                                                                                                                 cuvs_cagra_float
+                                                                                                                                                                                                                   .cu
+                                                                                                                                                                                                                     src /
+                                                                                                                                                                                                                 cuvs /
+                                                                                                                                                                                                                 cuvs_cagra_half
+                                                                                                                                                                                                                   .cu
+                                                                                                                                                                                                                     src /
+                                                                                                                                                                                                                 cuvs /
+                                                                                                                                                                                                                 cuvs_cagra_int8_t
+                                                                                                                                                                                                                   .cu
+                                                                                                                                                                                                                     src /
+                                                                                                                                                                                                                 cuvs /
+                                                                                                                                                                                                                 cuvs_cagra_uint8_t
+                                                                                                                                                                                                                   .cu
+                                                                                                                                                                                                                     LINKS cuvs) ConfigureAnnBench(NAME CUVS_CAGRA_MERGE
+                                                                                                                                                                                                                                                     PATH
+                                                                                                                                                                                                                                                       src /
+                                                                                                                                                                                                                                                   cuvs /
+                                                                                                                                                                                                                                                   cuvs_cagra_merge
+                                                                                                                                                                                                                                                     .cu
+                                                                                                                                                                                                                                                       src /
+                                                                                                                                                                                                                                                   cuvs /
+                                                                                                                                                                                                                                                   cuvs_cagra_merge_float
+                                                                                                                                                                                                                                                     .cu
+                                                                                                                                                                                                                                                       src /
+                                                                                                                                                                                                                                                   cuvs /
+                                                                                                                                                                                                                                                   cuvs_cagra_merge_half
+                                                                                                                                                                                                                                                     .cu
+                                                                                                                                                                                                                                                       src /
+                                                                                                                                                                                                                                                   cuvs /
+                                                                                                                                                                                                                                                   cuvs_cagra_merge_int8
+                                                                                                                                                                                                                                                     .cu
+                                                                                                                                                                                                                                                       src /
+                                                                                                                                                                                                                                                   cuvs /
+                                                                                                                                                                                                                                                   cuvs_cagra_merge_uint8
+                                                                                                                                                                                                                                                     .cu LINKS cuvs) endif()
+
+                                                                                                                                                                if (
+                                                                                                                                                                  CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB)
+                                                                                                                                                                  ConfigureAnnBench(NAME
+                                                                                                                                                                                      CUVS_CAGRA_HNSWLIB PATH
+                                                                                                                                                                                        src /
+                                                                                                                                                                                    cuvs /
+                                                                                                                                                                                    cuvs_cagra_hnswlib
+                                                                                                                                                                                      .cu LINKS
+                                                                                                                                                                                        cuvs)
+                                                                                                                                                                    endif()
+
+                                                                                                                                                                      if (CUVS_ANN_BENCH_USE_CUVS_MG) ConfigureAnnBench(
+                                                                                                                                                                        NAME CUVS_MG PATH
+                                                                                                                                                                            src /
+                                                                                                                                                                          cuvs /
+                                                                                                                                                                          cuvs_benchmark
+                                                                                                                                                                            .cu
+                                                                                                                                                                              $ <
+                                                                                                                                                                        $ < BOOL : ${CUVS_ANN_BENCH_USE_CUVS_MG} > : src /
+                                                                                                                                                                                                                     cuvs /
+                                                                                                                                                                                                                     cuvs_mg_ivf_flat
+                                                                                                                                                                                                                       .cu >
+                                                                                                                                                                        $ <
+                                                                                                                                                                        $ <
+                                                                                                                                                                        BOOL : ${CUVS_ANN_BENCH_USE_CUVS_MG} > : src /
+                                                                                                                                                                                                                 cuvs /
+                                                                                                                                                                                                                 cuvs_mg_ivf_pq
+                                                                                                                                                                                                                   .cu >
+                                                                                                                                                                        $ < $ < BOOL : ${CUVS_ANN_BENCH_USE_CUVS_MG} > : src /
+                                                                                                                                                                                                                         cuvs /
+                                                                                                                                                                                                                         cuvs_mg_cagra
+                                                                                                                                                                                                                           .cu >
+                                                                                                                                                                        LINKS cuvs
+                                                                                                                                                                          nccl)
+                                                                                                                                                                        endif()
+
+                                                                                                                                                                          message(
+                                                                                                                                                                            "CUVS_FAISS_TARGETS: ${CUVS_FAISS_TARGETS}")
+                                                                                                                                                                            message(
+                                                                                                                                                                              "CUDAToolkit_LIBRARY_DIR: ${CUDAToolkit_LIBRARY_DIR}") if (CUVS_ANN_BENCH_USE_FAISS_CPU_FLAT) ConfigureAnnBench(NAME FAISS_CPU_FLAT PATH src / faiss /
+                                                                                                                                                                                                                                                                                              faiss_cpu_benchmark
+                                                                                                                                                                                                                                                                                                .cpp LINKS
+                                                                                                                                                                                                                                                                                                  ${CUVS_FAISS_TARGETS}) endif()
+
+                                                                                                                                                                              if (
+                                                                                                                                                                                CUVS_ANN_BENCH_USE_FAISS_CPU_IVF_FLAT) ConfigureAnnBench(NAME FAISS_CPU_IVF_FLAT
+                                                                                                                                                                                                                                           PATH src /
+                                                                                                                                                                                                                                         faiss /
+                                                                                                                                                                                                                                         faiss_cpu_benchmark
+                                                                                                                                                                                                                                           .cpp LINKS
+                                                                                                                                                                                                                                             ${CUVS_FAISS_TARGETS})
+                                                                                                                                                                                endif()
+
+                                                                                                                                                                                  if (
+                                                                                                                                                                                    CUVS_ANN_BENCH_USE_FAISS_CPU_IVF_PQ) ConfigureAnnBench(NAME FAISS_CPU_IVF_PQ
+                                                                                                                                                                                                                                             PATH
+                                                                                                                                                                                                                                               src /
+                                                                                                                                                                                                                                           faiss /
+                                                                                                                                                                                                                                           faiss_cpu_benchmark
+                                                                                                                                                                                                                                             .cpp
+                                                                                                                                                                                                                                               LINKS ${
+                                                                                                                                                                                                                                                 CUVS_FAISS_TARGETS}) endif()
+
+                                                                                                                                                                                    if (
+                                                                                                                                                                                      CUVS_ANN_BENCH_USE_FAISS_CPU_HNSW_FLAT)
+                                                                                                                                                                                      ConfigureAnnBench(
+                                                                                                                                                                                        NAME FAISS_CPU_HNSW_FLAT
+                                                                                                                                                                                          PATH
+                                                                                                                                                                                            src /
+                                                                                                                                                                                        faiss /
+                                                                                                                                                                                        faiss_cpu_benchmark
+                                                                                                                                                                                          .cpp LINKS
+                                                                                                                                                                                            ${CUVS_FAISS_TARGETS})
+                                                                                                                                                                                        endif()
+
+                                                                                                                                                                                          if (CUVS_ANN_BENCH_USE_FAISS_GPU_IVF_FLAT AND CUVS_FAISS_ENABLE_GPU) ConfigureAnnBench(
+                                                                                                                                                                                            NAME FAISS_GPU_IVF_FLAT
+                                                                                                                                                                                              PATH
+                                                                                                                                                                                                src /
+                                                                                                                                                                                            faiss /
+                                                                                                                                                                                            faiss_gpu_benchmark
+                                                                                                                                                                                              .cu LINKS ${
+                                                                                                                                                                                                CUVS_FAISS_TARGETS} raft::
+                                                                                                                                                                                                raft) endif()
+
+                                                                                                                                                                                            if (
+                                                                                                                                                                                              CUVS_ANN_BENCH_USE_FAISS_GPU_IVF_PQ AND CUVS_FAISS_ENABLE_GPU) ConfigureAnnBench(NAME FAISS_GPU_IVF_PQ PATH src /
+                                                                                                                                                                                                                                                                               faiss /
+                                                                                                                                                                                                                                                                               faiss_gpu_benchmark
+                                                                                                                                                                                                                                                                                 .cu LINKS
+                                                                                                                                                                                                                                                                                   ${CUVS_FAISS_TARGETS} raft::
+                                                                                                                                                                                                                                                                                     raft)
+                                                                                                                                                                                              endif()
+
+                                                                                                                                                                                                if (
+                                                                                                                                                                                                  CUVS_ANN_BENCH_USE_FAISS_GPU_FLAT
+                                                                                                                                                                                                    AND CUVS_FAISS_ENABLE_GPU) ConfigureAnnBench(NAME FAISS_GPU_FLAT PATH
+                                                                                                                                                                                                                                                   src /
+                                                                                                                                                                                                                                                 faiss /
+                                                                                                                                                                                                                                                 faiss_gpu_benchmark
+                                                                                                                                                                                                                                                   .cu LINKS
+                                                                                                                                                                                                                                                     ${CUVS_FAISS_TARGETS} raft::
+                                                                                                                                                                                                                                                       raft)
+                                                                                                                                                                                                  endif()
+
+                                                                                                                                                                                                    if (CUVS_ANN_BENCH_USE_FAISS_GPU_CAGRA AND CUVS_FAISS_ENABLE_GPU) ConfigureAnnBench(NAME FAISS_GPU_CAGRA
+                                                                                                                                                                                                                                                                                          PATH
+                                                                                                                                                                                                                                                                                            src /
+                                                                                                                                                                                                                                                                                        faiss /
+                                                                                                                                                                                                                                                                                        faiss_gpu_benchmark
+                                                                                                                                                                                                                                                                                          .cu LINKS
+                                                                                                                                                                                                                                                                                            ${CUVS_FAISS_TARGETS} raft::
+                                                                                                                                                                                                                                                                                              raft)
+                                                                                                                                                                                                      endif()
+
+                                                                                                                                                                                                        if (
+                                                                                                                                                                                                          CUVS_ANN_BENCH_USE_FAISS_GPU_CAGRA_HNSW
+                                                                                                                                                                                                            AND
+                                                                                                                                                                                                              CUVS_FAISS_ENABLE_GPU)
+                                                                                                                                                                                                          ConfigureAnnBench(
+                                                                                                                                                                                                            NAME FAISS_GPU_CAGRA_HNSW
+                                                                                                                                                                                                              PATH
+                                                                                                                                                                                                                src /
+                                                                                                                                                                                                            faiss /
+                                                                                                                                                                                                            faiss_gpu_benchmark
+                                                                                                                                                                                                              .cu LINKS
+                                                                                                                                                                                                                ${CUVS_FAISS_TARGETS} raft::
+                                                                                                                                                                                                                  raft)
+                                                                                                                                                                                                            endif()
+
+                                                                                                                                                                                                              if (
+                                                                                                                                                                                                                CUVS_ANN_BENCH_USE_GGNN) include(cmake /
+                                                                                                                                                                                                                                                 thirdparty / get_glog) ConfigureAnnBench(NAME GGNN
+                                                                                                                                                                                                                                                                                            PATH
+                                                                                                                                                                                                                                                                                              src /
+                                                                                                                                                                                                                                                                                          ggnn /
+                                                                                                                                                                                                                                                                                          ggnn_benchmark
+                                                                                                                                                                                                                                                                                            .cu LINKS glog::glog ggnn::ggnn CUDA::
+                                                                                                                                                                                                                                                                                              curand) endif()
+
+                                                                                                                                                                                                                if (
+                                                                                                                                                                                                                  CUVS_ANN_BENCH_USE_DISKANN) ConfigureAnnBench(NAME DISKANN_MEMORY
+                                                                                                                                                                                                                                                                  PATH
+                                                                                                                                                                                                                                                                    src /
+                                                                                                                                                                                                                                                                diskann /
+                                                                                                                                                                                                                                                                diskann_benchmark
+                                                                                                                                                                                                                                                                  .cpp
+                                                                                                                                                                                                                                                                    LINKS
+                                                                                                                                                                                                                                                                      diskann::
+                                                                                                                                                                                                                                                                        diskann aio) ConfigureAnnBench(NAME DISKANN_SSD
+                                                                                                                                                                                                                                                                                                         PATH
+                                                                                                                                                                                                                                                                                                           src /
+                                                                                                                                                                                                                                                                                                       diskann /
+                                                                                                                                                                                                                                                                                                       diskann_benchmark
+                                                                                                                                                                                                                                                                                                         .cpp
+                                                                                                                                                                                                                                                                                                           LINKS
+                                                                                                                                                                                                                                                                                                             diskann::
+                                                                                                                                                                                                                                                                                                               diskann aio) endif()
+
+                                                                                                                                                                                                                  if (
+                                                                                                                                                                                                                    CUVS_ANN_BENCH_USE_CUVS_VAMANA)
+                                                                                                                                                                                                                    ConfigureAnnBench(
+                                                                                                                                                                                                                      NAME CUVS_VAMANA
+                                                                                                                                                                                                                        PATH
+                                                                                                                                                                                                                          src /
+                                                                                                                                                                                                                      cuvs /
+                                                                                                                                                                                                                      cuvs_vamana
+                                                                                                                                                                                                                        .cu LINKS cuvs
+                                                                                                                                                                                                                          diskann::
+                                                                                                                                                                                                                            diskann
+                                                                                                                                                                                                                              aio)
+                                                                                                                                                                                                                      endif()
+
+# ##################################################################################################
+#* Dynamically - \
+  loading ANN_BENCH executable -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+                                                                                                                                                                                                                        if (
+                                                                                                                                                                                                                          CUVS_ANN_BENCH_SINGLE_EXE) add_executable(ANN_BENCH
+                                                                                                                                                                                                                                                                      src /
+                                                                                                                                                                                                                                                                    common /
+                                                                                                                                                                                                                                                                    benchmark
+                                                                                                                                                                                                                                                                      .cpp)
+
+                                                                                                                                                                                                                          target_include_directories(
+                                                                                                                                                                                                                            ANN_BENCH PRIVATE
+                                                                                                                                                                                                                              ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+
+                                                                                                                                                                                                                            target_link_libraries(
+                                                                                                                                                                                                                              ANN_BENCH PRIVATE raft::raft nlohmann_json::nlohmann_json
+                                                                                                                                                                                                                                benchmark::benchmark
+                                                                                                                                                                                                                                  dl $<$<
+                                                                                                                                                                                                                                    TARGET_EXISTS : CUDA::
+                                                                                                                                                                                                                                      nvtx3> : CUDA::
+                                                                                                                                                                                                                                         nvtx3>)
+                                                                                                                                                                                                                              set_target_properties(
+                                                                                                                                                                                                                                ANN_BENCH PROPERTIES #set target compile options CXX_STANDARD 17 CXX_STANDARD_REQUIRED
+                                                                                                                                                                                                                                  ON CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED
+                                                                                                                                                                                                                                    ON POSITION_INDEPENDENT_CODE
+                                                                                                                                                                                                                                      ON INTERFACE_POSITION_INDEPENDENT_CODE
+                                                                                                                                                                                                                                        ON BUILD_RPATH
+                                                                                                                                                                                                                                "\$ORIGIN" INSTALL_RPATH
+                                                                                                                                                                                                                                "\$ORIGIN")
+                                                                                                                                                                                                                                target_compile_definitions(ANN_BENCH
+                                                                                                                                                                                                                                                             PRIVATE
+                                                                                                                                                                                                                                                               $<$<BOOL : ${CUDAToolkit_FOUND}> : ANN_BENCH_LINK_CUDART =
+                                                                                                                                                                                                                                                                   "libcudart.so.${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}.${CUDAToolkit_VERSION_PATCH}">)
+
+                                                                                                                                                                                                                                  target_link_options(
+                                                                                                                                                                                                                                    ANN_BENCH
+                                                                                                                                                                                                                                      PRIVATE -
+                                                                                                                                                                                                                                    export -
+                                                                                                                                                                                                                                    dynamic)
+
+                                                                                                                                                                                                                                    install(TARGETS ANN_BENCH COMPONENT ann_bench DESTINATION
+                                                                                                                                                                                                                                              bin /
+                                                                                                                                                                                                                                            ann
+                                                                                                                                                                                                                                              EXCLUDE_FROM_ALL)
+                                                                                                                                                                                                                                      endif()

--- a/cpp/bench/ann/src/cuvs/cuvs_ann_bench_param_parser.h
+++ b/cpp/bench/ann/src/cuvs/cuvs_ann_bench_param_parser.h
@@ -36,6 +36,7 @@ extern template class cuvs::bench::cuvs_ivf_pq<uint8_t, int64_t>;
 extern template class cuvs::bench::cuvs_ivf_pq<int8_t, int64_t>;
 #endif
 #if defined(CUVS_ANN_BENCH_USE_CUVS_CAGRA) || defined(CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB)
+#include "cuvs_cagra_merge_wrapper.h"
 #include "cuvs_cagra_wrapper.h"
 #endif
 #ifdef CUVS_ANN_BENCH_USE_CUVS_CAGRA
@@ -43,6 +44,10 @@ extern template class cuvs::bench::cuvs_cagra<float, uint32_t>;
 extern template class cuvs::bench::cuvs_cagra<half, uint32_t>;
 extern template class cuvs::bench::cuvs_cagra<uint8_t, uint32_t>;
 extern template class cuvs::bench::cuvs_cagra<int8_t, uint32_t>;
+extern template class cuvs::bench::cuvs_cagra_merge<float, uint32_t>;
+extern template class cuvs::bench::cuvs_cagra_merge<half, uint32_t>;
+extern template class cuvs::bench::cuvs_cagra_merge<uint8_t, uint32_t>;
+extern template class cuvs::bench::cuvs_cagra_merge<int8_t, uint32_t>;
 #endif
 
 #ifdef CUVS_ANN_BENCH_USE_CUVS_MG
@@ -182,6 +187,23 @@ void parse_search_param(const nlohmann::json& conf,
   parse_dynamic_batching_params(conf, param);
 }
 #endif
+
+template <typename T, typename IdxT>
+void parse_build_param(const nlohmann::json& conf,
+                       typename cuvs::bench::cuvs_cagra_merge<T, IdxT>::build_param& param)
+{
+  parse_build_param<T, IdxT>(conf, param.cagra_params);
+  if (conf.contains("split_size")) { param.split_size = conf.at("split_size"); }
+  if (conf.contains("n_splits")) { param.n_splits = conf.at("n_splits"); }
+  if (conf.contains("merge_strategy")) {
+    std::string strategy = conf.at("merge_strategy");
+    if (strategy == "LOGICAL") {
+      param.strategy = cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_LOGICAL;
+    } else {
+      param.strategy = cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_PHYSICAL;
+    }
+  }
+}
 
 #if defined(CUVS_ANN_BENCH_USE_CUVS_CAGRA) || defined(CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB) || \
   defined(CUVS_ANN_BENCH_USE_CUVS_MG)

--- a/cpp/bench/ann/src/cuvs/cuvs_benchmark.cu
+++ b/cpp/bench/ann/src/cuvs/cuvs_benchmark.cu
@@ -108,6 +108,11 @@ auto create_algo(const std::string& algo_name,
     parse_build_param<T, uint32_t>(conf, param);
     a = std::make_unique<cuvs::bench::cuvs_cagra<T, uint32_t>>(metric, dim, param);
   }
+  if (algo_name == "cuvs_cagra_merge") {
+    typename cuvs::bench::cuvs_cagra_merge<T, uint32_t>::build_param param;
+    parse_build_param<T, uint32_t>(conf, param);
+    a = std::make_unique<cuvs::bench::cuvs_cagra_merge<T, uint32_t>>(metric, dim, param);
+  }
 #endif
 #ifdef CUVS_ANN_BENCH_USE_CUVS_MG
   if constexpr (std::is_same_v<T, float> || std::is_same_v<T, uint8_t> ||
@@ -174,6 +179,9 @@ auto create_search_param(const std::string& algo_name, const nlohmann::json& con
     auto param = std::make_unique<typename cuvs::bench::cuvs_cagra<T, uint32_t>::search_param>();
     parse_search_param<T, uint32_t>(conf, *param);
     return param;
+  }
+  if (algo_name == "cuvs_cagra_merge") {
+    return std::make_unique<typename cuvs::bench::cuvs_cagra_merge<T, uint32_t>::search_param>();
   }
 #endif
 #ifdef CUVS_ANN_BENCH_USE_CUVS_MG

--- a/cpp/bench/ann/src/cuvs/cuvs_cagra_merge.cu
+++ b/cpp/bench/ann/src/cuvs/cuvs_cagra_merge.cu
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "../common/ann_types.hpp"
+#include "cuvs_ann_bench_param_parser.h"
+#include "cuvs_cagra_merge_wrapper.h"
+
+namespace cuvs::bench {
+
+template <typename T>
+auto create_algo(const std::string& algo_name,
+                 const std::string& distance,
+                 int dim,
+                 const nlohmann::json& conf) -> std::unique_ptr<cuvs::bench::algo<T>>
+{
+  [[maybe_unused]] cuvs::bench::Metric metric = parse_metric(distance);
+  std::unique_ptr<cuvs::bench::algo<T>> a;
+
+  if (algo_name == "cuvs_cagra_merge") {
+    typename cuvs::bench::cuvs_cagra_merge<T, uint32_t>::build_param param;
+    parse_build_param<T, uint32_t>(conf, param);
+    a = std::make_unique<cuvs::bench::cuvs_cagra_merge<T, uint32_t>>(metric, dim, param);
+  }
+
+  if (!a) { throw std::runtime_error("invalid algo: '" + algo_name + "'"); }
+
+  return a;
+}
+
+template <typename T>
+auto create_search_param(const std::string& algo_name, const nlohmann::json& conf)
+  -> std::unique_ptr<typename cuvs::bench::algo<T>::search_param>
+{
+  (void)conf;
+  if (algo_name == "cuvs_cagra_merge") {
+    return std::make_unique<typename cuvs::bench::cuvs_cagra_merge<T, uint32_t>::search_param>();
+  }
+
+  throw std::runtime_error("invalid algo: '" + algo_name + "'");
+}
+
+}  // namespace cuvs::bench
+
+REGISTER_ALGO_INSTANCE(float);
+REGISTER_ALGO_INSTANCE(half);
+REGISTER_ALGO_INSTANCE(std::int8_t);
+REGISTER_ALGO_INSTANCE(std::uint8_t);
+
+#ifdef ANN_BENCH_BUILD_MAIN
+#include "../common/benchmark.hpp"
+int main(int argc, char** argv) { return cuvs::bench::run_main(argc, argv); }
+#endif

--- a/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_float.cu
+++ b/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_float.cu
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cuvs_cagra_merge_wrapper.h"
+
+namespace cuvs::bench {
+template class cuvs_cagra_merge<float, uint32_t>;
+}  // namespace cuvs::bench

--- a/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_half.cu
+++ b/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_half.cu
@@ -1,0 +1,5 @@
+#include "cuvs_cagra_merge_wrapper.h"
+
+namespace cuvs::bench {
+template class cuvs_cagra_merge<half, uint32_t>;
+}  // namespace cuvs::bench

--- a/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_int8.cu
+++ b/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_int8.cu
@@ -1,0 +1,5 @@
+#include "cuvs_cagra_merge_wrapper.h"
+
+namespace cuvs::bench {
+template class cuvs_cagra_merge<int8_t, uint32_t>;
+}  // namespace cuvs::bench

--- a/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_uint8.cu
+++ b/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_uint8.cu
@@ -1,0 +1,5 @@
+#include "cuvs_cagra_merge_wrapper.h"
+
+namespace cuvs::bench {
+template class cuvs_cagra_merge<uint8_t, uint32_t>;
+}  // namespace cuvs::bench

--- a/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_wrapper.h
+++ b/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_wrapper.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../common/ann_types.hpp"
+#include "cuvs_ann_bench_utils.h"
+
+#include <cuvs/neighbors/cagra.hpp>
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/device_resources.hpp>
+#include <raft/util/cudart_utils.hpp>
+
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace cuvs::bench {
+
+template <typename T, typename IdxT>
+class cuvs_cagra_merge : public algo<T>, public algo_gpu {
+ public:
+  using search_param_base = typename algo<T>::search_param;
+
+  struct search_param : public search_param_base {};
+
+  struct build_param {
+    cuvs::neighbors::cagra::index_params cagra_params;
+    uint32_t split_size = 0;
+    uint32_t n_splits   = 1;
+    cuvs::neighbors::cagra::MergeStrategy strategy =
+      cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_PHYSICAL;
+  };
+
+  cuvs_cagra_merge(Metric metric, int dim, const build_param& param)
+    : algo<T>(metric, dim), params_(param)
+  {
+    params_.cagra_params.metric = parse_metric_type(metric);
+  }
+
+  void build(const T* dataset, size_t nrow) final
+  {
+    if (params_.split_size == 0 && params_.n_splits > 0) {
+      params_.split_size = raft::ceildiv<uint32_t>(static_cast<uint32_t>(nrow), params_.n_splits);
+    }
+    if (params_.n_splits == 0 && params_.split_size > 0) {
+      params_.n_splits = raft::ceildiv<uint32_t>(static_cast<uint32_t>(nrow), params_.split_size);
+    }
+    if (params_.n_splits == 0) { params_.n_splits = 1; }
+    if (params_.split_size == 0) { params_.split_size = static_cast<uint32_t>(nrow); }
+
+    indices_.clear();
+    index_ptrs_.clear();
+
+    bool dataset_is_on_host = raft::get_device_for_address(dataset) == -1;
+
+    for (uint32_t i = 0; i < params_.n_splits; ++i) {
+      IdxT start = static_cast<IdxT>(i) * params_.split_size;
+      if (start >= static_cast<IdxT>(nrow)) break;
+      IdxT rows      = std::min<IdxT>(params_.split_size, static_cast<IdxT>(nrow) - start);
+      auto extents   = raft::make_extents<IdxT>(rows, this->dim_);
+      auto view_host = raft::make_mdspan<const T, IdxT, raft::row_major, true, false>(
+        dataset + static_cast<size_t>(start) * this->dim_, extents);
+      auto view_dev = raft::make_mdspan<const T, IdxT, raft::row_major, false, true>(
+        dataset + static_cast<size_t>(start) * this->dim_, extents);
+      indices_.emplace_back(
+        std::move(dataset_is_on_host
+                    ? cuvs::neighbors::cagra::build(handle_, params_.cagra_params, view_host)
+                    : cuvs::neighbors::cagra::build(handle_, params_.cagra_params, view_dev)));
+      index_ptrs_.push_back(&indices_.back());
+    }
+
+    cuvs::neighbors::cagra::merge_params m_params{params_.cagra_params};
+    m_params.strategy = params_.strategy;
+    merged_index_     = std::make_shared<cuvs::neighbors::cagra::index<T, IdxT>>(
+      std::move(cuvs::neighbors::cagra::merge(handle_, m_params, index_ptrs_)));
+  }
+
+  void set_search_param(const search_param_base&, const void*) override {}
+
+  void search(const T*, int, int, algo_base::index_type*, float*) const override
+  {
+    throw std::runtime_error("search not supported for merge benchmark");
+  }
+
+  [[nodiscard]] auto get_preference() const -> algo_property override
+  {
+    algo_property property{};
+    property.dataset_memory_type = MemoryType::kHost;
+    property.query_memory_type   = MemoryType::kHost;
+    return property;
+  }
+
+  [[nodiscard]] auto get_sync_stream() const noexcept -> cudaStream_t override
+  {
+    return handle_.get_sync_stream();
+  }
+
+  void save(const std::string& file) const override
+  {
+    cuvs::neighbors::cagra::serialize(handle_, *merged_index_, file);
+  }
+
+  void load(const std::string& file) override
+  {
+    merged_index_ = std::make_shared<cuvs::neighbors::cagra::index<T, IdxT>>(
+      cuvs::neighbors::cagra::deserialize<T, IdxT>(handle_, file));
+  }
+
+  std::unique_ptr<algo<T>> copy() override
+  {
+    return std::make_unique<cuvs_cagra_merge<T, IdxT>>(*this);
+  }
+
+ private:
+  configured_raft_resources handle_{};
+  build_param params_{};
+  std::vector<cuvs::neighbors::cagra::index<T, IdxT>> indices_{};
+  std::vector<cuvs::neighbors::cagra::index<T, IdxT>*> index_ptrs_{};
+  std::shared_ptr<cuvs::neighbors::cagra::index<T, IdxT>> merged_index_{};
+};
+
+}  // namespace cuvs::bench


### PR DESCRIPTION
## Summary
- benchmark merging CAGRA indices
- parse merge parameters
- wire new benchmark into build

## Testing
- `clang-format -i cpp/bench/ann/src/cuvs/cuvs_cagra_merge_wrapper.h cpp/bench/ann/src/cuvs/cuvs_cagra_merge.cu cpp/bench/ann/src/cuvs/cuvs_cagra_merge_float.cu cpp/bench/ann/src/cuvs/cuvs_cagra_merge_half.cu cpp/bench/ann/src/cuvs/cuvs_cagra_merge_int8.cu cpp/bench/ann/src/cuvs/cuvs_cagra_merge_uint8.cu cpp/bench/ann/src/cuvs/cuvs_benchmark.cu cpp/bench/ann/CMakeLists.txt cpp/bench/ann/src/cuvs/cuvs_ann_bench_param_parser.h`