### PR TITLE
Add CAGRA merge benchmark

### DIFF
--- a/cpp/bench/ann/CMakeLists.txt
+++ b/cpp/bench/ann/CMakeLists.txt
@@ -239,6 +239,14 @@ if(CUVS_ANN_BENCH_USE_CUVS_CAGRA)
     LINKS
     cuvs
   )
+  ConfigureAnnBench(
+    NAME
+    CUVS_CAGRA_MERGE
+    PATH
+    src/cuvs/cuvs_cagra_merge.cu
+    LINKS
+    cuvs
+  )
 endif()
 
 if(CUVS_ANN_BENCH_USE_CUVS_CAGRA_HNSWLIB)

--- a/cpp/bench/ann/src/cuvs/cuvs_cagra_merge.cu
+++ b/cpp/bench/ann/src/cuvs/cuvs_cagra_merge.cu
@@ -1,0 +1,79 @@
+/*
+ * Benchmark for cuvs::neighbors::cagra::merge API
+ */
+#include "cuvs_cagra_merge_wrapper.h"
+#include "cuvs_ann_bench_param_parser.h"
+#include "../common/ann_types.hpp"
+
+namespace cuvs::bench {
+
+template <typename T, typename IdxT>
+void parse_build_param(const nlohmann::json& conf,
+                       typename cuvs::bench::cuvs_cagra_merge<T, IdxT>::build_param& param)
+{
+  typename cuvs::bench::cuvs_cagra<T, IdxT>::build_param tmp;
+  parse_build_param<T, IdxT>(conf, tmp);
+  param.index_params = tmp.cagra_params;
+  if (conf.contains("splits")) { param.splits = conf.at("splits"); }
+  if (conf.contains("merge_strategy")) {
+    std::string s = conf.at("merge_strategy");
+    if (s == "PHYSICAL" || s == "physical") {
+      param.strategy = cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_PHYSICAL;
+    } else if (s == "LOGICAL" || s == "logical") {
+      param.strategy = cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_LOGICAL;
+    }
+  }
+}
+
+template <typename T, typename IdxT>
+void parse_search_param(const nlohmann::json& conf,
+                        typename cuvs::bench::cuvs_cagra_merge<T, IdxT>::search_param& param)
+{
+  parse_search_param<T, IdxT>(conf, param);
+}
+
+template <typename T>
+auto create_algo(const std::string& algo_name,
+                 const std::string& distance,
+                 int dim,
+                 const nlohmann::json& conf) -> std::unique_ptr<cuvs::bench::algo<T>>
+{
+  cuvs::bench::Metric metric = parse_metric(distance);
+  std::unique_ptr<cuvs::bench::algo<T>> a;
+
+  if constexpr (std::is_same_v<T, float> || std::is_same_v<T, half> ||
+                std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t>) {
+    if (algo_name == "cuvs_cagra_merge") {
+      typename cuvs::bench::cuvs_cagra_merge<T, uint32_t>::build_param param;
+      parse_build_param<T, uint32_t>(conf, param);
+      a = std::make_unique<cuvs::bench::cuvs_cagra_merge<T, uint32_t>>(metric, dim, param);
+    }
+  }
+  if (!a) { throw std::runtime_error("invalid algo: '" + algo_name + "'"); }
+  return a;
+}
+
+template <typename T>
+auto create_search_param(const std::string& algo_name, const nlohmann::json& conf)
+  -> std::unique_ptr<typename cuvs::bench::algo<T>::search_param>
+{
+  if (algo_name == "cuvs_cagra_merge") {
+    auto param = std::make_unique<typename cuvs::bench::cuvs_cagra_merge<T, uint32_t>::search_param>();
+    parse_search_param<T, uint32_t>(conf, *param);
+    return param;
+  }
+  throw std::runtime_error("invalid algo: '" + algo_name + "'");
+}
+
+}  // namespace cuvs::bench
+
+REGISTER_ALGO_INSTANCE(float);
+REGISTER_ALGO_INSTANCE(half);
+REGISTER_ALGO_INSTANCE(std::int8_t);
+REGISTER_ALGO_INSTANCE(std::uint8_t);
+
+#ifdef ANN_BENCH_BUILD_MAIN
+#include "../common/benchmark.hpp"
+int main(int argc, char** argv) { return cuvs::bench::run_main(argc, argv); }
+#endif
+

--- a/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_wrapper.h
+++ b/cpp/bench/ann/src/cuvs/cuvs_cagra_merge_wrapper.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "cuvs_ann_bench_utils.h"
+#include "../common/ann_types.hpp"
+#include <cuvs/neighbors/cagra.hpp>
+#include <memory>
+#include <vector>
+
+namespace cuvs::bench {
+
+template <typename T, typename IdxT>
+class cuvs_cagra_merge : public algo<T>, public algo_gpu {
+ public:
+  using search_param_base = typename algo<T>::search_param;
+  struct build_param {
+    cuvs::neighbors::cagra::index_params index_params{};
+    uint32_t splits{2};
+    cuvs::neighbors::cagra::MergeStrategy strategy{
+      cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_PHYSICAL};
+  };
+  struct search_param : public search_param_base {
+    cuvs::neighbors::cagra::search_params params{};
+  };
+
+  cuvs_cagra_merge(Metric metric, int dim, const build_param& param)
+    : algo<T>(metric, dim), build_param_(param)
+  {
+    build_param_.index_params.metric = parse_metric_type(metric);
+  }
+
+  void build(const T* dataset, size_t nrow) final;
+  void set_search_param(const search_param_base& param, const void* filter) override;
+  void search(const T* queries,
+              int batch_size,
+              int k,
+              algo_base::index_type* neighbors,
+              float* distances) const override;
+
+  [[nodiscard]] auto get_sync_stream() const noexcept -> cudaStream_t override
+  {
+    return handle_.get_sync_stream();
+  }
+
+  [[nodiscard]] auto get_preference() const -> algo_property override
+  {
+    return {MemoryType::kHost, MemoryType::kHost};
+  }
+
+  void save(const std::string& file) const override;
+  void load(const std::string& file) override;
+  std::unique_ptr<algo<T>> copy() override
+  {
+    return std::make_unique<cuvs_cagra_merge<T, IdxT>>(*this);
+  }
+
+ private:
+  configured_raft_resources handle_{};
+  build_param build_param_{};
+  std::vector<cuvs::neighbors::cagra::index<T, IdxT>> sub_indices_{};
+  std::shared_ptr<cuvs::neighbors::cagra::index<T, IdxT>> index_{};
+  std::shared_ptr<cuvs::neighbors::cagra::composite_index<T, IdxT>> composite_{};
+  cuvs::neighbors::cagra::search_params search_params_{};
+};
+
+// Implementation
+
+template <typename T, typename IdxT>
+void cuvs_cagra_merge<T, IdxT>::build(const T* dataset, size_t nrow)
+{
+  sub_indices_.clear();
+  sub_indices_.reserve(build_param_.splits);
+  size_t base = 0;
+  size_t chunk = nrow / build_param_.splits;
+  for (uint32_t i = 0; i < build_param_.splits; ++i) {
+    size_t size = (i == build_param_.splits - 1) ? (nrow - base) : chunk;
+    auto view = raft::make_host_matrix_view<const T, int64_t, raft::row_major>(
+      dataset + base * this->dim_, size, this->dim_);
+    sub_indices_.push_back(
+      cuvs::neighbors::cagra::build(handle_, build_param_.index_params, view));
+    base += size;
+  }
+  std::vector<cuvs::neighbors::cagra::index<T, IdxT>*> ptrs;
+  ptrs.reserve(sub_indices_.size());
+  for (auto& idx : sub_indices_) ptrs.push_back(&idx);
+  cuvs::neighbors::cagra::merge_params mp{build_param_.index_params};
+  mp.strategy = build_param_.strategy;
+  if (build_param_.strategy == cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_PHYSICAL) {
+    index_ = std::make_shared<cuvs::neighbors::cagra::index<T, IdxT>>(cuvs::neighbors::cagra::merge(handle_, mp, ptrs));
+    composite_.reset();
+  } else {
+    composite_ = std::make_shared<cuvs::neighbors::cagra::composite_index<T, IdxT>>(cuvs::neighbors::cagra::make_composite_index(mp, ptrs));
+    index_.reset();
+  }
+}
+
+template <typename T, typename IdxT>
+void cuvs_cagra_merge<T, IdxT>::set_search_param(const search_param_base& param, const void*)
+{
+  auto& sp = dynamic_cast<const search_param&>(param);
+  search_params_ = sp.params;
+}
+
+template <typename T, typename IdxT>
+void cuvs_cagra_merge<T, IdxT>::search(const T* queries,
+                                       int batch_size,
+                                       int k,
+                                       algo_base::index_type* neighbors,
+                                       float* distances) const
+{
+  auto qv = raft::make_device_matrix_view<const T, int64_t>(queries, batch_size, this->dim_);
+  auto nv = raft::make_device_matrix_view<IdxT, int64_t>((IdxT*)neighbors, batch_size, k);
+  auto dv = raft::make_device_matrix_view<float, int64_t>(distances, batch_size, k);
+  if (index_) {
+    cuvs::neighbors::cagra::search(handle_, search_params_, *index_, qv, nv, dv);
+  } else if (composite_) {
+    cuvs::neighbors::cagra::search(handle_, search_params_, *composite_, qv, nv, dv);
+  }
+}
+
+template <typename T, typename IdxT>
+void cuvs_cagra_merge<T, IdxT>::save(const std::string& file) const
+{
+  if (index_) { cuvs::neighbors::cagra::serialize(handle_, *index_, file); }
+}
+
+template <typename T, typename IdxT>
+void cuvs_cagra_merge<T, IdxT>::load(const std::string& file)
+{
+  index_ = std::make_shared<cuvs::neighbors::cagra::index<T, IdxT>>(handle_);
+  cuvs::neighbors::cagra::deserialize(handle_, file, index_.get());
+  composite_.reset();
+}
+
+}  // namespace cuvs::bench
+

--- a/python/cuvs_bench/cuvs_bench/config/algorithms.yaml
+++ b/python/cuvs_bench/cuvs_bench/config/algorithms.yaml
@@ -37,6 +37,9 @@ cuvs_ivf_pq:
 cuvs_cagra:
   executable: CUVS_CAGRA_ANN_BENCH
   requires_gpu: true
+cuvs_cagra_merge:
+  executable: CUVS_CAGRA_MERGE_ANN_BENCH
+  requires_gpu: true
 cuvs_brute_force:
   executable: CUVS_BRUTE_FORCE_ANN_BENCH
   requires_gpu: true

--- a/python/cuvs_bench/cuvs_bench/config/algos/cuvs_cagra_merge.yaml
+++ b/python/cuvs_bench/cuvs_bench/config/algos/cuvs_cagra_merge.yaml
@@ -1,0 +1,15 @@
+name: cuvs_cagra_merge
+constraints:
+  build: cuvs_bench.config.algos.constraints.cuvs_cagra_build
+  search: cuvs_bench.config.algos.constraints.cuvs_cagra_search
+groups:
+  base:
+    build:
+      graph_degree: [32, 64]
+      intermediate_graph_degree: [32, 64]
+      graph_build_algo: ["NN_DESCENT"]
+      splits: [2]
+      merge_strategy: ["PHYSICAL", "LOGICAL"]
+    search:
+      itopk: [64]
+      search_width: [1, 2]


### PR DESCRIPTION
## Summary
- add `cuvs_cagra_merge` benchmark for the CAGRA merge API
- wire new benchmark target into CMake
- expose the new benchmark through python configs

## Testing
- `pre-commit` *(fails: pre-commit not installed)*