### PR TITLE
Refine composite index wrappers

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -418,6 +418,9 @@ if(BUILD_SHARED_LIBS)
     src/neighbors/detail/cagra/cagra_build.cpp
     src/neighbors/detail/cagra/topk_for_cagra/topk.cu
     src/neighbors/dynamic_batching.cu
+    src/neighbors/cagra_wrapper.cu
+    src/neighbors/composite_wrapper.cu
+    src/neighbors/composite/merge.cpp
     $<$<BOOL:${BUILD_CAGRA_HNSWLIB}>:src/neighbors/hnsw.cpp>
     src/neighbors/ivf_flat_index.cpp
     src/neighbors/ivf_flat/ivf_flat_build_extend_float_int64_t.cu

--- a/cpp/include/cuvs/neighbors/common.hpp
+++ b/cpp/include/cuvs/neighbors/common.hpp
@@ -96,6 +96,9 @@ struct index_params {
 
 struct search_params {};
 
+/** Base merge parameters. */
+struct merge_params {};
+
 /** @} */  // end group neighbors_index
 
 /** Two-dimensional dataset; maybe owning, maybe compressed, maybe strided. */

--- a/cpp/include/cuvs/neighbors/composite/index_iface.hpp
+++ b/cpp/include/cuvs/neighbors/composite/index_iface.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuvs/neighbors/common.hpp>
+#include <cuvs/neighbors/cagra.hpp>
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/resources.hpp>
+#include <memory>
+#include <vector>
+
+namespace cuvs::neighbors::composite {
+
+/**
+ * @brief Polymorphic index interface used by composite indexing.
+ */
+template <typename T, typename IdxT>
+struct IIndex {
+  using value_type  = T;
+  using index_type  = IdxT;
+  using dataset_idx = int64_t;
+
+  virtual ~IIndex() = default;
+
+  /**
+   * @brief Search the index.
+   */
+  virtual void search(const raft::resources& handle,
+                      const cuvs::neighbors::search_params& params,
+                      raft::device_matrix_view<const T, dataset_idx, raft::row_major> queries,
+                      raft::device_matrix_view<IdxT, dataset_idx, raft::row_major> neighbors,
+                      raft::device_matrix_view<float, dataset_idx, raft::row_major> distances,
+                      const cuvs::neighbors::filtering::base_filter& filter =
+                        cuvs::neighbors::filtering::none_sample_filter{}) const = 0;
+};
+
+/**
+ * @brief Wrapper for a CAGRA index implementing IIndex.
+ */
+template <typename T, typename IdxT>
+class CagraIndexWrapper : public IIndex<T, IdxT> {
+ public:
+  using index_type  = IdxT;
+  using value_type  = T;
+
+  explicit CagraIndexWrapper(cuvs::neighbors::cagra::index<T, IdxT>* idx) : index_(idx) {}
+
+  void search(const raft::resources& handle,
+              const cuvs::neighbors::search_params& params,
+              raft::device_matrix_view<const T, int64_t, raft::row_major> queries,
+              raft::device_matrix_view<IdxT, int64_t, raft::row_major> neighbors,
+              raft::device_matrix_view<float, int64_t, raft::row_major> distances,
+              const cuvs::neighbors::filtering::base_filter& filter =
+                cuvs::neighbors::filtering::none_sample_filter{}) const override;
+
+ private:
+  cuvs::neighbors::cagra::index<T, IdxT>* index_;
+};
+
+/**
+ * @brief Composite index made of other IIndex implementations.
+ */
+template <typename T, typename IdxT>
+class CompositeIndexWrapper : public IIndex<T, IdxT> {
+ public:
+  using index_ptr = std::shared_ptr<IIndex<T, IdxT>>;
+
+  explicit CompositeIndexWrapper(std::vector<index_ptr> children)
+    : children_(std::move(children))
+  {
+  }
+
+  void search(const raft::resources& handle,
+              const cuvs::neighbors::search_params& params,
+              raft::device_matrix_view<const T, int64_t, raft::row_major> queries,
+              raft::device_matrix_view<IdxT, int64_t, raft::row_major> neighbors,
+              raft::device_matrix_view<float, int64_t, raft::row_major> distances,
+              const cuvs::neighbors::filtering::base_filter& filter =
+                cuvs::neighbors::filtering::none_sample_filter{}) const override;
+
+ private:
+  std::vector<index_ptr> children_;
+};
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/include/cuvs/neighbors/composite/merge.hpp
+++ b/cpp/include/cuvs/neighbors/composite/merge.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "index_iface.hpp"
+
+#include <cuvs/neighbors/cagra.hpp>
+
+namespace cuvs::neighbors::composite {
+
+/**
+ * @brief Merge a collection of CAGRA indices using the requested strategy.
+ */
+template <typename T, typename IdxT>
+std::shared_ptr<IIndex<T, IdxT>> merge(
+  const raft::resources& handle,
+  const cuvs::neighbors::cagra::merge_params& params,
+  std::vector<cuvs::neighbors::cagra::index<T, IdxT>*>& indices);
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/src/neighbors/cagra_wrapper.cu
+++ b/cpp/src/neighbors/cagra_wrapper.cu
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuvs/neighbors/composite/index_iface.hpp>
+
+namespace cuvs::neighbors::composite {
+
+template <typename T, typename IdxT>
+void CagraIndexWrapper<T, IdxT>::search(
+  const raft::resources& handle,
+  const cuvs::neighbors::search_params& params,
+  raft::device_matrix_view<const T, int64_t, raft::row_major> queries,
+  raft::device_matrix_view<IdxT, int64_t, raft::row_major> neighbors,
+  raft::device_matrix_view<float, int64_t, raft::row_major> distances,
+  const cuvs::neighbors::filtering::base_filter& filter) const
+{
+  auto const& cagra_params = dynamic_cast<const cuvs::neighbors::cagra::search_params&>(params);
+  cuvs::neighbors::cagra::search(handle, cagra_params, *index_, queries, neighbors, distances, filter);
+}
+
+// explicit instantiations
+template class CagraIndexWrapper<float, uint32_t>;
+template class CagraIndexWrapper<half, uint32_t>;
+template class CagraIndexWrapper<int8_t, uint32_t>;
+template class CagraIndexWrapper<uint8_t, uint32_t>;
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/src/neighbors/composite/merge.cpp
+++ b/cpp/src/neighbors/composite/merge.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuvs/neighbors/composite/merge.hpp>
+
+namespace cuvs::neighbors::composite {
+
+template <typename T, typename IdxT>
+std::shared_ptr<IIndex<T, IdxT>> merge(
+  const raft::resources& handle,
+  const cuvs::neighbors::cagra::merge_params& params,
+  std::vector<cuvs::neighbors::cagra::index<T, IdxT>*>& indices)
+{
+  if (params.strategy == cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_LOGICAL) {
+    auto comp = cuvs::neighbors::cagra::make_composite_index<T, IdxT>(params, indices);
+    std::vector<std::shared_ptr<IIndex<T, IdxT>>> wrappers;
+    wrappers.reserve(comp.sub_indices.size());
+    for (auto* idx : comp.sub_indices) {
+      wrappers.push_back(std::make_shared<CagraIndexWrapper<T, IdxT>>(idx));
+    }
+    return std::make_shared<CompositeIndexWrapper<T, IdxT>>(std::move(wrappers));
+  } else {
+    auto out = cuvs::neighbors::cagra::merge<T, IdxT>(handle, params, indices);
+    auto* idx = new decltype(out)(std::move(out));
+    return std::make_shared<CagraIndexWrapper<T, IdxT>>(idx);
+  }
+}
+
+// explicit instantiation
+#define INSTANTIATE(T, IdxT) \
+  template std::shared_ptr<IIndex<T, IdxT>> merge<T, IdxT>( \
+    const raft::resources&, const cuvs::neighbors::cagra::merge_params&, \
+    std::vector<cuvs::neighbors::cagra::index<T, IdxT>*>&);
+
+INSTANTIATE(float, uint32_t);
+INSTANTIATE(half, uint32_t);
+INSTANTIATE(int8_t, uint32_t);
+INSTANTIATE(uint8_t, uint32_t);
+
+#undef INSTANTIATE
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/src/neighbors/composite_wrapper.cu
+++ b/cpp/src/neighbors/composite_wrapper.cu
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuvs/neighbors/composite/index_iface.hpp>
+#include <cuvs/selection/select_k.hpp>
+#include <raft/core/copy.hpp>
+#include <raft/core/device_mdarray.hpp>
+
+namespace cuvs::neighbors::composite {
+
+template <typename T, typename IdxT>
+void CompositeIndexWrapper<T, IdxT>::search(
+  const raft::resources& handle,
+  const cuvs::neighbors::search_params& params,
+  raft::device_matrix_view<const T, int64_t, raft::row_major> queries,
+  raft::device_matrix_view<IdxT, int64_t, raft::row_major> neighbors,
+  raft::device_matrix_view<float, int64_t, raft::row_major> distances,
+  const cuvs::neighbors::filtering::base_filter& filter) const
+{
+  if (children_.empty()) { return; }
+  if (children_.size() == 1) {
+    children_.front()->search(handle, params, queries, neighbors, distances, filter);
+    return;
+  }
+
+  auto n_query = queries.extent(0);
+  auto k       = neighbors.extent(1);
+  auto total_k = k * static_cast<int64_t>(children_.size());
+
+  auto tmp_dists = raft::make_device_matrix<float, int64_t>(handle, n_query, total_k);
+  auto tmp_inds  = raft::make_device_matrix<IdxT, int64_t>(handle, n_query, total_k);
+
+  int64_t offset = 0;
+  for (auto const& child : children_) {
+    auto sub_neigh = raft::device_matrix_view<IdxT, int64_t, raft::row_major>(
+      tmp_inds.data_handle() + offset, raft::make_matrix_extent<int64_t>(n_query, k));
+    auto sub_dist = raft::device_matrix_view<float, int64_t, raft::row_major>(
+      tmp_dists.data_handle() + offset, raft::make_matrix_extent<int64_t>(n_query, k));
+    child->search(handle, params, queries, sub_neigh, sub_dist, filter);
+    offset += k * n_query;
+  }
+
+  cuvs::selection::select_k(handle,
+                            tmp_dists.view(),
+                            tmp_inds.view(),
+                            distances,
+                            neighbors,
+                            true,
+                            true);
+}
+
+// explicit instantiation
+template class CompositeIndexWrapper<float, uint32_t>;
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/tests/neighbors/ann_cagra.cuh
+++ b/cpp/tests/neighbors/ann_cagra.cuh
@@ -23,6 +23,7 @@
 
 #include <cuvs/distance/distance.hpp>
 #include <cuvs/neighbors/cagra.hpp>
+#include <cuvs/neighbors/composite/merge.hpp>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/device_resources.hpp>
 #include <raft/core/host_mdarray.hpp>
@@ -1079,16 +1080,9 @@ class AnnCagraIndexMergeTest : public ::testing::TestWithParam<AnnCagraInputs> {
         search_params.team_size   = ps.team_size;
         search_params.itopk_size  = ps.itopk_size;
 
-        if (merge_params.strategy ==
-            cuvs::neighbors::cagra::MergeStrategy::MERGE_STRATEGY_PHYSICAL) {
-          auto index = cagra::merge(handle_, merge_params, indices);
-          cagra::search(
-            handle_, search_params, index, search_queries_view, indices_out_view, dists_out_view);
-        } else {
-          auto index = cagra::make_composite_index(merge_params, indices);
-          cagra::search(
-            handle_, search_params, index, search_queries_view, indices_out_view, dists_out_view);
-        }
+        auto index = cuvs::neighbors::composite::merge(handle_, merge_params, indices);
+        index->search(
+          handle_, search_params, search_queries_view, indices_out_view, dists_out_view);
 
         raft::update_host(distances_Cagra.data(), distances_dev.data(), queries_size, stream_);
         raft::update_host(indices_Cagra.data(), indices_dev.data(), queries_size, stream_);


### PR DESCRIPTION
## Summary
- collect all composite wrappers in `index_iface.hpp`
- add base `merge_params` struct
- move wrapper implementations and update CMake
- unify CAGRA tests to use the composite `merge` API

## Testing
- `pre-commit run --files cpp/CMakeLists.txt cpp/include/cuvs/neighbors/common.hpp cpp/include/cuvs/neighbors/composite/index_iface.hpp cpp/include/cuvs/neighbors/composite/merge.hpp cpp/src/neighbors/cagra_wrapper.cu cpp/src/neighbors/composite_wrapper.cu cpp/src/neighbors/composite/merge.cpp cpp/tests/neighbors/ann_cagra.cuh` *(fails: `pre-commit: command not found`)*