### PR TITLE
Add polymorphic index wrappers

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -404,6 +404,7 @@ if(BUILD_SHARED_LIBS)
     src/neighbors/cagra_merge_half.cu
     src/neighbors/cagra_merge_int8.cu
     src/neighbors/cagra_merge_uint8.cu
+    src/neighbors/composite/merge.cpp
     src/neighbors/iface/iface_cagra_float_uint32_t.cu
     src/neighbors/iface/iface_cagra_half_uint32_t.cu
     src/neighbors/iface/iface_cagra_int8_t_uint32_t.cu

--- a/cpp/include/cuvs/neighbors/composite/cagra_index_wrapper.hpp
+++ b/cpp/include/cuvs/neighbors/composite/cagra_index_wrapper.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "iindex.hpp"
+#include <cuvs/neighbors/cagra.hpp>
+
+namespace cuvs::neighbors::composite {
+
+/**
+ * @brief Wrapper for a CAGRA index providing the `IIndex` interface.
+ */
+template <typename T, typename IdxT>
+class CagraIndexWrapper : public IIndex<T, IdxT> {
+ public:
+  explicit CagraIndexWrapper(cuvs::neighbors::cagra::index<T, IdxT>&& idx)
+    : index_(std::move(idx))
+  {
+  }
+
+  const cuvs::neighbors::cagra::index<T, IdxT>& get() const { return index_; }
+
+  void search(const raft::resources& handle,
+              const cuvs::neighbors::search_params& params,
+              raft::device_matrix_view<const T, int64_t, raft::row_major> queries,
+              raft::device_matrix_view<IdxT, int64_t, raft::row_major> neighbors,
+              raft::device_matrix_view<float, int64_t, raft::row_major> distances,
+              const cuvs::neighbors::filtering::base_filter& filter =
+                cuvs::neighbors::filtering::none_sample_filter{}) const override
+  {
+    auto const& cagra_params = static_cast<cuvs::neighbors::cagra::search_params const&>(params);
+    cuvs::neighbors::cagra::search(handle, cagra_params, index_, queries, neighbors, distances, filter);
+  }
+
+ private:
+  cuvs::neighbors::cagra::index<T, IdxT> index_;
+};
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/include/cuvs/neighbors/composite/composite_index_wrapper.hpp
+++ b/cpp/include/cuvs/neighbors/composite/composite_index_wrapper.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "iindex.hpp"
+#include <memory>
+#include <vector>
+
+namespace cuvs::neighbors::composite {
+
+/**
+ * @brief A wrapper that aggregates multiple `IIndex` implementations.
+ *
+ * The current implementation simply dispatches search to the first child index
+ * and ignores the others. This can be extended to merge results from all
+ * sub-indices.
+ */
+template <typename T, typename IdxT>
+class CompositeIndexWrapper : public IIndex<T, IdxT> {
+ public:
+  explicit CompositeIndexWrapper(std::vector<std::shared_ptr<IIndex<T, IdxT>>> children)
+    : children_(std::move(children))
+  {
+  }
+
+  void search(const raft::resources& handle,
+              const cuvs::neighbors::search_params& params,
+              raft::device_matrix_view<const T, int64_t, raft::row_major> queries,
+              raft::device_matrix_view<IdxT, int64_t, raft::row_major> neighbors,
+              raft::device_matrix_view<float, int64_t, raft::row_major> distances,
+              const cuvs::neighbors::filtering::base_filter& filter =
+                cuvs::neighbors::filtering::none_sample_filter{}) const override
+  {
+    if (children_.empty()) return;
+    // TODO: merge results from all child indices
+    children_.front()->search(handle, params, queries, neighbors, distances, filter);
+  }
+
+ private:
+  std::vector<std::shared_ptr<IIndex<T, IdxT>>> children_;
+};
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/include/cuvs/neighbors/composite/iindex.hpp
+++ b/cpp/include/cuvs/neighbors/composite/iindex.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuvs/neighbors/common.hpp>
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/resources.hpp>
+
+namespace cuvs::neighbors::composite {
+
+/**
+ * @brief Polymorphic interface for cuVS nearest neighbor indices.
+ *
+ * This interface allows using different index implementations through
+ * a common `search()` method.
+ */
+template <typename T, typename IdxT>
+struct IIndex {
+  using value_type  = T;
+  using index_type  = IdxT;
+
+  virtual ~IIndex() = default;
+
+  /**
+   * @brief Perform kNN search on the index.
+   */
+  virtual void search(const raft::resources& handle,
+                      const cuvs::neighbors::search_params& params,
+                      raft::device_matrix_view<const T, int64_t, raft::row_major> queries,
+                      raft::device_matrix_view<IdxT, int64_t, raft::row_major> neighbors,
+                      raft::device_matrix_view<float, int64_t, raft::row_major> distances,
+                      const cuvs::neighbors::filtering::base_filter& filter =
+                        cuvs::neighbors::filtering::none_sample_filter{}) const = 0;
+};
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/include/cuvs/neighbors/composite/merge.hpp
+++ b/cpp/include/cuvs/neighbors/composite/merge.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cagra_index_wrapper.hpp"
+#include "composite_index_wrapper.hpp"
+#include <cuvs/neighbors/cagra.hpp>
+#include <memory>
+#include <vector>
+
+namespace cuvs::neighbors::composite {
+
+/**
+ * @brief Create a unified index from multiple CAGRA indices.
+ *
+ * Depending on the merge strategy, either physically merges the indices or
+ * creates a logical composite. The returned object implements `IIndex`.
+ */
+template <typename T, typename IdxT>
+std::shared_ptr<IIndex<T, IdxT>> merge(
+  const raft::resources& handle,
+  const cuvs::neighbors::cagra::merge_params& params,
+  std::vector<cuvs::neighbors::cagra::index<T, IdxT>*>& indices)
+{
+  using namespace cuvs::neighbors;
+  if (params.strategy == cagra::MergeStrategy::MERGE_STRATEGY_PHYSICAL) {
+    auto merged = cagra::merge<T, IdxT>(handle, params, indices);
+    return std::make_shared<CagraIndexWrapper<T, IdxT>>(std::move(merged));
+  } else {
+    auto comp = cagra::make_composite_index<T, IdxT>(params, indices);
+    std::vector<std::shared_ptr<IIndex<T, IdxT>>> children;
+    children.reserve(comp.sub_indices.size());
+    for (auto* idx : comp.sub_indices) {
+      children.push_back(std::make_shared<CagraIndexWrapper<T, IdxT>>(*idx));
+    }
+    return std::make_shared<CompositeIndexWrapper<T, IdxT>>(std::move(children));
+  }
+}
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/include/cuvs/neighbors/composite/tiered_index_wrapper.hpp
+++ b/cpp/include/cuvs/neighbors/composite/tiered_index_wrapper.hpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ */
+
+#pragma once
+
+#include "iindex.hpp"
+#include <raft/util/raft_expectations.hpp>
+
+namespace cuvs::neighbors::composite {
+
+template <typename T, typename IdxT>
+class TieredIndexWrapper : public IIndex<T, IdxT> {
+ public:
+  void search(const raft::resources&,
+              const cuvs::neighbors::search_params&,
+              raft::device_matrix_view<const T, int64_t, raft::row_major>,
+              raft::device_matrix_view<IdxT, int64_t, raft::row_major>,
+              raft::device_matrix_view<float, int64_t, raft::row_major>,
+              const cuvs::neighbors::filtering::base_filter&) const override
+  {
+    RAFT_FAIL("TieredIndexWrapper not implemented");
+  }
+};
+
+}  // namespace cuvs::neighbors::composite
+

--- a/cpp/src/neighbors/composite/merge.cpp
+++ b/cpp/src/neighbors/composite/merge.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuvs/neighbors/composite/merge.hpp>
+
+namespace cuvs::neighbors::composite {
+
+#define CUVS_INSTANTIATE_MERGE(T, IdxT)                                       \
+  template std::shared_ptr<IIndex<T, IdxT>> merge<T, IdxT>(                   \
+    const raft::resources&,                                                   \
+    const cuvs::neighbors::cagra::merge_params&,                              \
+    std::vector<cuvs::neighbors::cagra::index<T, IdxT>*>&);
+
+CUVS_INSTANTIATE_MERGE(float, uint32_t);
+CUVS_INSTANTIATE_MERGE(half, uint32_t);
+CUVS_INSTANTIATE_MERGE(uint8_t, uint32_t);
+CUVS_INSTANTIATE_MERGE(int8_t, uint32_t);
+
+#undef CUVS_INSTANTIATE_MERGE
+
+}  // namespace cuvs::neighbors::composite
+


### PR DESCRIPTION
## Summary
- introduce `IIndex` polymorphic interface for ANN indices
- add `CagraIndexWrapper`, `CompositeIndexWrapper`, and placeholder `TieredIndexWrapper`
- provide `merge` helper returning unified wrapper
- compile new sources in CMake

## Testing
- `pre-commit` *(fails: command not found)*